### PR TITLE
Announcement: See More link to view all text. Grid color to purple

### DIFF
--- a/src/components/AnnoucementGrid.jsx
+++ b/src/components/AnnoucementGrid.jsx
@@ -1,9 +1,12 @@
-import React from "react";
+import React, { useState } from "react";
 import Row from "react-bootstrap/Row";
 import Col from "react-bootstrap/Col";
 import Container from "react-bootstrap/Container";
+import "../style/main.css";
 
 const AnnouncementGrid = (props) => {
+  const [showMore, setShowMore] = useState(false);
+
   return (
     <>
       <h4 className="text-center mt-5">{props.title}</h4>
@@ -18,7 +21,17 @@ const AnnouncementGrid = (props) => {
                   </p>
                   <p>{item.Date}</p>
                 </div>
-                <p>{item.Story}</p>
+                <p>{showMore ? item.Story : item.Story.substring(0, 150)}</p>
+                <span
+                  onClick={() => setShowMore(!showMore)}
+                  className="showMoreStyle"
+                >
+                  {item.Story.length > 200
+                    ? showMore
+                      ? "Hide"
+                      : "Show More"
+                    : null}
+                </span>
               </div>
             </Col>
           ))}

--- a/src/style/main.css
+++ b/src/style/main.css
@@ -4,7 +4,7 @@
   --titleImageUrl: url("https://images.pexels.com/photos/209224/pexels-photo-209224.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1");
   --gridHeight: 250px;
   --shadow: 0 3px 10px rgba(104, 104, 104, 0.3);
-  --gridColor: #daefe7;
+  --gridColor: #eeeaf2;
 }
 
 /* Main Styles */
@@ -28,6 +28,7 @@
   margin-bottom: 2rem;
   box-shadow: var(--shadow);
   font-family: "Roboto";
+  word-wrap: break-word;
 }
 
 .gridImage {
@@ -112,4 +113,9 @@
 
 .title {
   background-color: #ece0b4;
+}
+
+.showMoreStyle {
+  color: darkblue;
+  text-align: right;
 }


### PR DESCRIPTION
Announcement page: 
For better UX, I made a "see more" link for long story items. Click to view entire story. Click again to condense.
An alternative is to have "see more" open into a separate page. But there are tradeoffs for UX

Also changed grid color to purple. 